### PR TITLE
Update esx_extraitems.sql

### DIFF
--- a/esx_extraitems.sql
+++ b/esx_extraitems.sql
@@ -1,3 +1,5 @@
+USE `es_extended`;
+
 INSERT INTO `items` (`name`, `label`, `weight`, `rare`, `can_remove`) VALUES
 	('darknet', 'Dark Net', 1, 0, 1),
 	('binoculars', 'Binoculars', 1, 0, 1),
@@ -21,5 +23,5 @@ INSERT INTO `shops` (store, item, price) VALUES
 	('ExtraItemsShop', 'oxygenmask', 400),
 	('ExtraItemsShop', 'weabox', 60),
 	('ExtraItemsShop', 'weaclip', 25),
-	('ExtraItemsShop', 'vehgps', 25),
+	('ExtraItemsShop', 'vehgps', 25)
 ;


### PR DESCRIPTION
Changed "('ExtraItemsShop', 'vehgps', 25)," to "('ExtraItemsShop', 'vehgps', 25)" to prevent error when importing and added USE `es_extended`; so the database doesn't need to be manually specified.